### PR TITLE
Selected option fixes for Safari and Firefox

### DIFF
--- a/js/bootstrap-colorselector-0.1.0/bootstrap-colorselector.js
+++ b/js/bootstrap-colorselector-0.1.0/bootstrap-colorselector.js
@@ -174,9 +174,11 @@
 			this.hidePicker();
 
 			// change HTML selected option
+			this.$select[0].selectedIndex = -1; // Safari
 			this.$select.children().removeAttr("selected");
 			this.$select.children("option[value='" + value + "']").attr(
 					"selected", true);
+			this.$select[0].value = value; // Firefox
 			// trigger the change-handler
 			this.$select.trigger("change");
 


### PR DESCRIPTION
In the case when the first option is a placeholder which has an empty value and data-color and the select option is dynamically populated from a database or restful service,  the selected option is not updated in Safari and Firefox. In Safari, the first and current option is selected. In Firefox, all options left deselected. To fix this, I set the selectedIndex to -1 for Safari and for Firefox I set the select's value to the colorDiv value.
