### PR TITLE
Remove CSS class conflict with date picker

### DIFF
--- a/css/bootstrap-colorselector-0.1.0/bootstrap-colorselector.css
+++ b/css/bootstrap-colorselector-0.1.0/bootstrap-colorselector.css
@@ -6,7 +6,7 @@
  *
  * Licensed under the MIT license
  */
-.colorselector.picker:before {
+.colorselector.bootstrap-colorpicker:before {
 	position: absolute;
 	top: -7px;
 	left: 9px;
@@ -18,7 +18,7 @@
 	content: '';
 }
 
-.colorselector.picker:after {
+.colorselector.bootstrap-colorpicker:after {
 	position: absolute;
 	top: -6px;
 	left: 10px;
@@ -29,7 +29,7 @@
 	content: '';
 }
 
-.colorselector.picker {
+.colorselector.bootstrap-colorpicker {
 	position: absolute;
 	top: 100%;
 	left: 0;

--- a/js/bootstrap-colorselector-0.1.0/bootstrap-colorselector.js
+++ b/js/bootstrap-colorselector-0.1.0/bootstrap-colorselector.js
@@ -50,7 +50,7 @@
 
 			// markup for the picker
 			var $markupPicker = $("<div>").addClass("colorselector").addClass(
-					"picker");
+					"bootstrap-colorpicker");
 
 			var colorCounter = 0;
 


### PR DESCRIPTION
There was a conflict over the `picker` class name with [pickdate.js](https://github.com/amsul/pickadate.js). I've changed it here so it's something unique to this project.
